### PR TITLE
Use $NODENV_ROOT for the correct purpose, and fix space-handling

### DIFF
--- a/nodenv.plugin.zsh
+++ b/nodenv.plugin.zsh
@@ -2,7 +2,7 @@ FOUND_NODENV=0
 nodenvdirs=("$HOME/.nodenv"  "/usr/local/opt/nodenv" "/usr/local/nodenv" "/opt/nodenv")
 
 for nodenvdir in "${nodenvdirs[@]}" ; do
-  if [ -d $nodenvdir/bin -a $FOUND_NODENV -eq 0 ] ; then
+  if [ -d $nodenvdir/versions -a $FOUND_NODENV -eq 0 ] ; then
     FOUND_NODENV=1
     if [[ $NODENV_ROOT = '' ]]; then
       NODENV_ROOT=$nodenvdir

--- a/nodenv.plugin.zsh
+++ b/nodenv.plugin.zsh
@@ -1,14 +1,14 @@
-FOUND_NODENV=0
+found_nodenv=''
 nodenvdirs=("$HOME/.nodenv"  "/usr/local/opt/nodenv" "/usr/local/nodenv" "/opt/nodenv")
 
 for nodenvdir in "${nodenvdirs[@]}" ; do
-  if [ -d $nodenvdir/versions -a $FOUND_NODENV -eq 0 ] ; then
-    FOUND_NODENV=1
-    if [[ $NODENV_ROOT = '' ]]; then
-      NODENV_ROOT=$nodenvdir
+  if [ -z "$found_nodenv" ] && [ -d "$nodenvdir/versions" ]; then
+    found_nodenv=true
+    if [ -z "$NODENV_ROOT" ]; then
+      NODENV_ROOT="$nodenvdir"
+      export NODENV_ROOT
     fi
-    export NODENV_ROOT
-    export PATH=${nodenvdir}/bin:$PATH
+    export PATH="${nodenvdir}/bin:$PATH"
     eval "$(nodenv init --no-rehash -)"
 
     function current_node() {
@@ -22,6 +22,8 @@ for nodenvdir in "${nodenvdirs[@]}" ; do
 done
 unset nodenvdir
 
-if [ $FOUND_NODENV -eq 0 ] ; then
-  function nodenv_prompt_info() { echo "system: $(node --version)" }
+if [ -z "$found_nodenv" ]; then
+  function nodenv_prompt_info() {
+     echo "system: $(node --version)"
+  }
 fi


### PR DESCRIPTION
Hope you don't mind me ripping out all the guts of your fork!

Your plugin assumed `nodenv` uses `$NODENV_ROOT` for the *installation of `nodenv` itself*, whereas it's actually supposed to be the directory where node-versions are installed and shims are generated. I ‘fixed’ the detection mechanism (well, for a given value of ‘fixed’ — it still assumes you've installed at least one Node version; not sure what to do about that.)

Also, in shell, always remember to **[Q.E.F.T.](http://mywiki.wooledge.org/Quotes)!** `;)`